### PR TITLE
Add types on tasks and events messages, RFC: 05

### DIFF
--- a/05-tasks-and-events.md
+++ b/05-tasks-and-events.md
@@ -178,15 +178,16 @@ In response to the `watch_transaction` task.
  2. data:
     - [`i32`: `id`]: The task identifier that emits this event
     - [`sha256`: `block`]: Hash of the block mining the transaction.
-    - [`u16`: `confirmations`]: Number of blocks after `block`
+    - [`i32`: `confirmations`]: Number of blocks after `block`, return `-1` for `None`
 
  - semantics:
-    - for transaction not seen on mempool, emit `(0x0, none)`
-    - for transaction seen on mempool but not mined, emit `(0x0, some(0))`
-    - for transaction mined, emit `(tx_block, some(confirmations))` where `tx_block` is the block that the transaction got mined, and `confirmations` is the number of blocks extending `tx_block`
-    - when `confirmations` >= `confirmation_bound`, emit `(tx_block, some(confirmation_bound))`. here `task` is considered successfully accomplished and terminates. at that time, transaction is considered final (=irreversible).
+    - for transaction not seen on mempool, emit `(0x0, None)`
+    - for transaction seen on mempool but not mined, emit `(0x0, Some(0))`
+    - for transaction mined, emit `(tx_block, Some(confirmations))` where `tx_block` is the block that the transaction got mined, and `confirmations` is the number of blocks extending `tx_block`
+    - when `confirmations` >= `confirmation_bound`, emit `(tx_block, Some(confirmation_bound))`. here `task` is considered successfully accomplished and terminates. at that time, transaction is considered final (=irreversible).
 
 Thus:
+
 ```
 for each transaction being watched by Syncer:
   for every new block arrival extending the chain that the transaction was mined:

--- a/05-tasks-and-events.md
+++ b/05-tasks-and-events.md
@@ -95,8 +95,8 @@ Bitcoin also has this task return historical transactions, with a possible rate 
 For Monero, the following parameters:
 
  2. data:
-    - [`u16`: `scalar_len`]
-    - [`scalar_len * byte`: `public_spend`]: The public spend key of the address.
+    - [`u16`: `point_len`]
+    - [`point_len * byte`: `public_spend`]: The public spend key of the address.
     - [`u16`: `scalar_len`]
     - [`scalar_len * byte`: `private_view`]: The private view key of the address.
     - [`u64`: `from_height`]: Previous blocks to scan for transactions sent to the specified address.

--- a/05-tasks-and-events.md
+++ b/05-tasks-and-events.md
@@ -180,11 +180,11 @@ In response to the `watch_transaction` task.
     - [`sha256`: `block`]: Hash of the block mining the transaction.
     - [`i32`: `confirmations`]: Number of blocks after `block`, return `-1` for `None`
 
- - semantics:
-    - for transaction not seen on mempool, emit `(0x0, None)`
-    - for transaction seen on mempool but not mined, emit `(0x0, Some(0))`
-    - for transaction mined, emit `(tx_block, Some(confirmations))` where `tx_block` is the block that the transaction got mined, and `confirmations` is the number of blocks extending `tx_block`
-    - when `confirmations` >= `confirmation_bound`, emit `(tx_block, Some(confirmation_bound))`. here `task` is considered successfully accomplished and terminates. at that time, transaction is considered final (=irreversible).
+ - Semantics:
+    - For transaction not seen on mempool, emit `(0x0, None)`
+    - For transaction seen on mempool but not mined, emit `(0x0, Some(0))`
+    - For transaction mined, emit `(tx_block, Some(confirmations))` where `tx_block` is the block that the transaction got mined, and `confirmations` is the number of blocks extending `tx_block`
+    - When `confirmations` >= `confirmation_bound`, emit `(tx_block, Some(confirmation_bound))`. Here `Task` is considered successfully accomplished and terminates. At that time, transaction is considered final (=irreversible).
 
 Thus:
 

--- a/05-tasks-and-events.md
+++ b/05-tasks-and-events.md
@@ -35,9 +35,9 @@ A syncer is responsible for carrying out assigned `tasks` received through incom
 
 Tasks MUST follow those rules:
 
-* The same task MUST be publishable multiple times without causing contradictory side effects
-* A task published more than once MUST always produce an equivalent set of events
-* Tasks MUST have a defined lifetime
+ * The same task MUST be publishable multiple times without causing contradictory side effects
+ * A task published more than once MUST always produce an equivalent set of events
+ * Tasks MUST have a defined lifetime
 
 Tasks are available from any syncer, yet their parameters vary depending on the network. Parameters are provided for Bitcoin and Monero to demonstrate how the protocol would be implemented. Any codebase working with Bitcoin or Monero SHOULD use the following definitions.
 
@@ -50,19 +50,25 @@ The `error` event is valid for every single task, and it takes the task's ID and
 This document frequently references epochs, whose definition is dependent on the protocol in question. For Bitcoin, Monero, and other blockchain-based systems, the epoch is the block height. For systems without the context of a block height, Unix timestamps SHOULD be used.
 
 ### The `abort` Task
+
 Aborts the task with id `id`.
 
-Data:
-- `id`: the task `id` that shall be aborted
+ 1. type: ? (`abort`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier that shall be aborted
 
-To update a task with id `id`, Syncer must receive an `abort` task aborting with `id` parameter, and subsequently submit a new instance of this task which shall have a new `id`.
+To update a task with identifier `id`, Syncer must receive an `abort` task aborting with `id` parameter, and subsequently submit a new instance of this task which shall have a new `id`.
 
 ### The `watch_height` Task
 
 `watch_height` asks the syncer for notifications about updates to the blockchain's `height` and associated `block` id. This task MUST be implemented for any coin with a blockchain. This task MAY be implemented for any coin without a blockchain. If it is not implemented, an error event must be sent in response to any attempt to start this task.
 
 Required parameters are:
-* `lifetime`: Epoch at which the syncer SHOULD drop this task. Until then, this task MUST be maintained, barring the case where an `abort` task aborts it.
+
+ 1. type: ? (`watch_height`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier
+    - [`u64`: `lifetime`]: Epoch at which the syncer SHOULD drop this task. Until then, this task MUST be maintained, barring the case where an `abort` task aborts it.
 
 Parameters may be added to specify which blockchain, in order to support any network utilizing multiple.
 
@@ -71,17 +77,29 @@ Parameters may be added to specify which blockchain, in order to support any net
 `watch_address` asks the syncer for notifications about when a specified address is involved in a transaction.
 
 Required parameters are:
-* `lifetime`: Epoch at which the syncer SHOULD drop this task. Until then, this task MUST be maintained, barring the case where an `abort` task aborts it.
+
+ 1. type: ? (`watch_height`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier
+    - [`u64`: `lifetime`]: Epoch at which the syncer SHOULD drop this task. Until then, this task MUST be maintained, barring the case where an `abort` task aborts it.
 
 For Bitcoin, the following additional parameters are defined:
-* `address`: The address to watch.
-* `from_height`: Previous blocks to scan for transactions sent to the specified address.
+
+ 2. data:
+    - [`u16`: `address_len`]
+    - [`address_len * byte`: `address`]: The address to watch.
+    - [`u64`: `from_height`]: Previous blocks to scan for transactions sent to the specified address.
+
 Bitcoin also has this task return historical transactions, with a possible rate limit being implementation-dependent.
 
 For Monero, the following parameters:
-* `public_spend`: The public spend key of the address.
-* `private_view`: The private view key of the address.
-* `from_height`: Previous blocks to scan for transactions sent to the specified address.
+
+ 2. data:
+    - [`u16`: `scalar_len`]
+    - [`scalar_len * byte`: `public_spend`]: The public spend key of the address.
+    - [`u16`: `scalar_len`]
+    - [`scalar_len * byte`: `private_view`]: The private view key of the address.
+    - [`u64`: `from_height`]: Previous blocks to scan for transactions sent to the specified address.
 
 `address_transaction` events are emitted as a response to the `watch_address` task.
 
@@ -90,9 +108,13 @@ For Monero, the following parameters:
 `watch_transaction` asks a syncer for updates on the status of a transaction.
 
 Required parameters are:
-* `hash`: Transaction hash.
-* `confirmation_bound`: Upper bound on the confirmation count until which the syncer should report updates on the block depth of the transaction. This task MUST be maintained until this threshold is reached or until `lifetime` has passed.
-* `lifetime`: Epoch at which the syncer SHOULD drop this task. This task MUST be maintained until this threshold is reached or until `confirmation_bound` has been reached.
+
+ 1. type: ? (`watch_transaction`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier
+    - [`sha256`: `hash`]: Transaction hash.
+    - [`u16`: `confirmation_bound`]: Upper bound on the confirmation count until which the syncer should report updates on the block depth of the transaction. This task MUST be maintained until this threshold is reached or until `lifetime` has passed.
+    - [`u64`: `lifetime`]: Epoch at which the syncer SHOULD drop this task. This task MUST be maintained until this threshold is reached or until `confirmation_bound` has been reached.
 
 Once a transaction is seen by the syncer, and passed the confirmation threshold, a `transaction_confirmations` event is emitted.
 
@@ -100,47 +122,69 @@ Once a transaction is seen by the syncer, and passed the confirmation threshold,
 
 `broadcast_transaction` tells a syncer to broadcast a transaction. The syncer MUST broadcast the transaction unless the transaction already in the blockchain or the mempool.
 
-The only parameter is:
-* `tx`: The raw transaction in its serialized format.
+ 1. type: ? (`broadcast_transaction`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier
+    - [`u16`: `tx_len`]
+    - [`tx_len * byte`: `tx`]: The raw transaction in its serialized format.
 
 The blockchain event in response is the `transaction_broadcasted` event.
 
 ## Blockchain Events
+
 The function of the Syncer is to emit events to accomplish its assigned tasks. Syncer's must emit events targeting the daemon (at a later stage of the project, potentially the client as well). Blockchain Events are produced by syncers in response to certain types of `tasks`. A task MAY produce multiple `blockchain event` messages. The `blockchain event` messages are as defined below.
 
 ### The `task_aborted` Event
-Event in response to `abort_task` Task, emitted only once.
-Data:
-* `id`: integer
-* `success_abort`: bool
+
+Event in response to `abort` task, emitted only once.
+
+ 1. type: ? (`task_aborted`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier aborted
+    - [`i32`: `success_abort`]: The status code, return 0 if task is aborted successfully
 
 ### The `height_changed` Event
-`watch_height` task was previously defined. That task emits `height changed` blockchain events. Upon new block arrival and reorgs, a `height_changed` event is emitted. It contains:
-* `block`: current block_hash
-* `height`: current blockchain height.
+
+`watch_height` task was previously defined. That task emits `height_changed` blockchain events. Upon new block arrival and reorgs, a `height_changed` event is emitted. It contains:
+
+ 1. type: ? (`height_changed`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier that emits this event
+    - [`sha256`: `block`]: Current block hash
+    - [`u64`: `height`]: Current blockchain height.
 
 Upon task reception, syncers MUST send a `height_changed` event immediately to signify the current height.
 
 ### The `address_transaction` Event
+
 Once a `watch_address` address is involved in a transaction, `address_transaction` is emitted. It contains:
-* `hash`: Transaction ID.
-* `amount`: Value of the amount sent to the specified address.
+
+ 1. type: ? (`address_transaction`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier that emits this event
+    - [`sha256`: `hash`]: Transaction ID.
+    - [`u64`: `amount`]: Value of the amount sent to the specified address.
 
 Further fields may be defined depending on the asset. Any asset based on a blockchain MUST also have:
-* `block`: hash of the block mining the transaction
+
+ 2. data:
+    - [`sha256`: `block`]: Hash of the block mining the transaction
 
 ### The `transaction_confirmations` Event
+
 In response to the `watch_transaction` task.
 
-- Data:
-  * `block`: hash of the block mining the transaction.
-  * `confirmations`: Number of blocks after `block`
+ 1. type: ? (`transaction_confirmations`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier that emits this event
+    - [`sha256`: `block`]: Hash of the block mining the transaction.
+    - [`u16`: `confirmations`]: Number of blocks after `block`
 
-- Semantics:
-    - For transaction not seen on mempool, emit `(0x0, None)`
-    - For transaction seen on mempool but not mined, emit `(0x0, Some(0))`
-    - For transaction mined, emit `(tx_block, Some(confirmations))` where `tx_block` is the block that the transaction got mined, and `confirmations` is the number of blocks extending `tx_block`
-    - When `confirmations` >= `confirmation_bound`, emit `(tx_block, Some(confirmation_bound))`. Here `Task` is considered successfully accomplished and terminates. At that time, transaction is considered final (=irreversible).
+ - semantics:
+    - for transaction not seen on mempool, emit `(0x0, none)`
+    - for transaction seen on mempool but not mined, emit `(0x0, some(0))`
+    - for transaction mined, emit `(tx_block, some(confirmations))` where `tx_block` is the block that the transaction got mined, and `confirmations` is the number of blocks extending `tx_block`
+    - when `confirmations` >= `confirmation_bound`, emit `(tx_block, some(confirmation_bound))`. here `task` is considered successfully accomplished and terminates. at that time, transaction is considered final (=irreversible).
 
 Thus:
 ```
@@ -153,12 +197,15 @@ for each transaction being watched by Syncer:
 Upon block reorg reverting transaction out of blockchain, emit `(0x0, Some(0))` if transaction shows back in mempool or `(0x0, None)` if it's not in the mempool.
 
 ### The `transaction_broadcasted` Event
+
 The `broadcast_transaction` task defined above produces upon successful transaction broadcast a success output message: `transaction_broadcasted` blockchain event.
 
-This message contains:
-* `tx`: The raw transaction in its serialized format.
-* `success_broadcast`: bool
-
+ 1. type: ? (`transaction_broadcasted`)
+ 2. data:
+    - [`i32`: `id`]: The task identifier that emits this event
+    - [`u16`: `tx_len`]
+    - [`tx_len * byte`: `tx`]: The raw transaction in its serialized format.
+    - [`i32`: `success_broadcast`]: The status code, return 0 if broadcast is successful
 
 FIXME: move to state RFC
 ### Equivalence of Event Sets

--- a/05-tasks-and-events.md
+++ b/05-tasks-and-events.md
@@ -52,17 +52,17 @@ This document frequently references epochs, whose definition is dependent on the
 ### The `abort` Task
 Aborts the task with id `id`.
 
-Data: 
+Data:
 - `id`: the task `id` that shall be aborted
 
-To update a task with id `id`, Syncer must receive an `abort` task aborting with `id` parameter, and subsequently submit a new instance of this task which shall have a new `id`. 
+To update a task with id `id`, Syncer must receive an `abort` task aborting with `id` parameter, and subsequently submit a new instance of this task which shall have a new `id`.
 
 ### The `watch_height` Task
 
 `watch_height` asks the syncer for notifications about updates to the blockchain's `height` and associated `block` id. This task MUST be implemented for any coin with a blockchain. This task MAY be implemented for any coin without a blockchain. If it is not implemented, an error event must be sent in response to any attempt to start this task.
 
 Required parameters are:
-* `lifetime`: Epoch at which the syncer SHOULD drop this task. Until then, this task MUST be maintained, barring the case where an `abort` task aborts it. 
+* `lifetime`: Epoch at which the syncer SHOULD drop this task. Until then, this task MUST be maintained, barring the case where an `abort` task aborts it.
 
 Parameters may be added to specify which blockchain, in order to support any network utilizing multiple.
 
@@ -92,9 +92,9 @@ For Monero, the following parameters:
 Required parameters are:
 * `hash`: Transaction hash.
 * `confirmation_bound`: Upper bound on the confirmation count until which the syncer should report updates on the block depth of the transaction. This task MUST be maintained until this threshold is reached or until `lifetime` has passed.
-* `lifetime`: Epoch at which the syncer SHOULD drop this task. This task MUST be maintained until this threshold is reached or until `confirmation_bound` has been reached. 
+* `lifetime`: Epoch at which the syncer SHOULD drop this task. This task MUST be maintained until this threshold is reached or until `confirmation_bound` has been reached.
 
-Once a transaction is seen by the syncer, and passed the confirmation threshold, a `transaction_confirmations` event is emitted. 
+Once a transaction is seen by the syncer, and passed the confirmation threshold, a `transaction_confirmations` event is emitted.
 
 ### The `broadcast_transaction` Task
 
@@ -106,7 +106,7 @@ The only parameter is:
 The blockchain event in response is the `transaction_broadcasted` event.
 
 ## Blockchain Events
-The function of the Syncer is to emit events to accomplish its assigned tasks. Syncer's must emit events targeting the daemon (at a later stage of the project, potentially the client as well). Blockchain Events are produced by syncers in response to certain types of `tasks`. A task MAY produce multiple `blockchain event` messages. The `blockchain event` messages are as defined below. 
+The function of the Syncer is to emit events to accomplish its assigned tasks. Syncer's must emit events targeting the daemon (at a later stage of the project, potentially the client as well). Blockchain Events are produced by syncers in response to certain types of `tasks`. A task MAY produce multiple `blockchain event` messages. The `blockchain event` messages are as defined below.
 
 ### The `task_aborted` Event
 Event in response to `abort_task` Task, emitted only once.
@@ -116,7 +116,7 @@ Data:
 
 ### The `height_changed` Event
 `watch_height` task was previously defined. That task emits `height changed` blockchain events. Upon new block arrival and reorgs, a `height_changed` event is emitted. It contains:
-* `block`: current block_hash 
+* `block`: current block_hash
 * `height`: current blockchain height.
 
 Upon task reception, syncers MUST send a `height_changed` event immediately to signify the current height.
@@ -132,7 +132,7 @@ Further fields may be defined depending on the asset. Any asset based on a block
 ### The `transaction_confirmations` Event
 In response to the `watch_transaction` task.
 
-- Data: 
+- Data:
   * `block`: hash of the block mining the transaction.
   * `confirmations`: Number of blocks after `block`
 
@@ -140,12 +140,12 @@ In response to the `watch_transaction` task.
     - For transaction not seen on mempool, emit `(0x0, None)`
     - For transaction seen on mempool but not mined, emit `(0x0, Some(0))`
     - For transaction mined, emit `(tx_block, Some(confirmations))` where `tx_block` is the block that the transaction got mined, and `confirmations` is the number of blocks extending `tx_block`
-    - When `confirmations` >= `confirmation_bound`, emit `(tx_block, Some(confirmation_bound))`. Here `Task` is considered successfully accomplished and terminates. At that time, transaction is considered final (=irreversible). 
+    - When `confirmations` >= `confirmation_bound`, emit `(tx_block, Some(confirmation_bound))`. Here `Task` is considered successfully accomplished and terminates. At that time, transaction is considered final (=irreversible).
 
 Thus:
 ```
 for each transaction being watched by Syncer:
-  for every new block arrival extending the chain that the transaction was mined: 
+  for every new block arrival extending the chain that the transaction was mined:
     if confirmations <= confirmation_bound:
       Syncer emits: `(tx_block, Some(confirmations))`
 ```
@@ -161,7 +161,7 @@ This message contains:
 
 
 FIXME: move to state RFC
-### Equivalence of Event Sets 
+### Equivalence of Event Sets
 
 When a task produces two different sets of blockchain events depending on when the task is handled by the syncer those two sets MUST have an equivalent impact on the state of the daemon at any point in time.
 


### PR DESCRIPTION
Fix #63 

Specify the serialization for tasks and events messages.